### PR TITLE
[ Feat ]: Board modifications permission granted only to admin and creator

### DIFF
--- a/whiteboard/WhiteboardApp.ts
+++ b/whiteboard/WhiteboardApp.ts
@@ -128,6 +128,7 @@ export class WhiteboardApp extends App implements IUIKitInteractionHandler {
         const whiteboardBoardCommand: WhiteboardCommand = new WhiteboardCommand(
             this
         );
+    
         await configuration.slashCommands.provideSlashCommand(
             whiteboardBoardCommand
         );

--- a/whiteboard/WhiteboardApp.ts
+++ b/whiteboard/WhiteboardApp.ts
@@ -257,7 +257,8 @@ export class UpdateBoardEndpoint extends ApiEndpoint {
             read.getPersistenceReader(),
             boardId
         );
-        const { messageId, privateMessageId, status } = savedBoardata;
+        console.log("savedBoardata", savedBoardata)
+        const { messageId, privateMessageId, status, boardOwner } = savedBoardata;
         const user = (await read.getMessageReader().getSenderUser(messageId))!;
         const room = await read.getMessageReader().getRoom(messageId);
         const AppSender = (await read.getUserReader().getAppUser()) as IUser;
@@ -277,7 +278,8 @@ export class UpdateBoardEndpoint extends ApiEndpoint {
                 cover,
                 title,
                 privateMessageId,
-                status
+                status,
+                boardOwner
             );
             if (privateMessageId.length > 0 && status == UtilityEnum.PRIVATE) {
                 if (directRoom) {

--- a/whiteboard/blocks/UtilityBlock.ts
+++ b/whiteboard/blocks/UtilityBlock.ts
@@ -95,27 +95,29 @@ export async function deletionHeaderBlock(
 // Header block for boardOwners to give permissions to the user
 export async function permissionHeaderBlock(
     username: string,
+    userForBoardPermission: string,
     boardname: string,
     appId: string,
 ): Promise<Array<Block>> {
     const block: Block[] = [];
 
     const grantPermissionButton = getButton(
-        "Edit board",
-        UtilityEnum.PREVIEW_BLOCK_ID,
-        UtilityEnum.OPEN_BUTTON_ACTION_ID,
+        "Allow",
+        UtilityEnum.PERMISSION_BLOCK_ID,
+        UtilityEnum.ALLOW_BUTTON_ACTION_ID,
         appId,
-        "Open",
+        `${username}, ${boardname}, ${userForBoardPermission}`,
         ButtonStyle.PRIMARY
     );
+    
 
     const denyPermissionButton = getButton(
-        "Settings",
-        UtilityEnum.PREVIEW_BLOCK_ID,
-        UtilityEnum.SETTINGS_BUTTON_ACTION_ID,
+        "Deny",
+        UtilityEnum.PERMISSION_BLOCK_ID,
+        UtilityEnum.DENY_BUTTON_ACTION_ID,
         appId,
-        "Settings",
-        undefined
+        `${username}, ${boardname}, ${userForBoardPermission}`,
+        ButtonStyle.DANGER
     );
 
     let markdownBlock: SectionBlock;
@@ -123,7 +125,7 @@ export async function permissionHeaderBlock(
             `${username} wants to edit *${boardname}*`
         );
 
-    const actionBlock = getActionsBlock(UtilityEnum.PREVIEW_BLOCK_ID, [
+    const actionBlock = getActionsBlock(UtilityEnum.PERMISSION_BLOCK_ID, [
         grantPermissionButton,
         denyPermissionButton
     ]);

--- a/whiteboard/blocks/UtilityBlock.ts
+++ b/whiteboard/blocks/UtilityBlock.ts
@@ -17,11 +17,65 @@ export async function buildHeaderBlock(
 ): Promise<Array<Block>> {
     const block: Block[] = [];
     const openbutton = getButton(
+        "Options",
+        UtilityEnum.PREVIEW_BLOCK_ID,
+        UtilityEnum.OPEN_BUTTON_ACTION_ID,
+        appId,
+        `${boardURL}, ${boardname}`,
+        ButtonStyle.PRIMARY
+    );
+
+    // const settingButton = getButton(
+    //     "Settings",
+    //     UtilityEnum.PREVIEW_BLOCK_ID,
+    //     UtilityEnum.SETTINGS_BUTTON_ACTION_ID,
+    //     appId,
+    //     "Settings",
+    //     undefined
+    // );
+
+    // const deleteButton = getDeleteButton(
+    //     "Delete board",
+    //     UtilityEnum.PREVIEW_BLOCK_ID,
+    //     UtilityEnum.DELETE_BUTTON_ACTION_ID,
+    //     appId,
+    //     "Delete",
+    //     ButtonStyle.DANGER
+    // );
+
+    let markdownBlock: SectionBlock;
+    if (boardname == undefined) {
+        markdownBlock = getMarkdownBlock(
+            `*Untitled Whiteboard* by \`@${username}\``
+        );
+    } else {
+        markdownBlock = getMarkdownBlock(`*${boardname}* by \`@${username}\``);
+    }
+
+    const actionBlock = getActionsBlock(UtilityEnum.PREVIEW_BLOCK_ID, [
+        // settingButton,
+        openbutton,
+        // deleteButton,
+    ]);
+    block.push(markdownBlock);
+    block.push(actionBlock);
+    return block;
+}
+
+// header block after permission is given
+export async function buildHeaderBlockAfterPermission(
+    username: string,
+    boardURL: string,
+    appId: string,
+    boardname?: string
+): Promise<Array<Block>> {
+    const block: Block[] = [];
+    const openbutton = getButton(
         "Edit board",
         UtilityEnum.PREVIEW_BLOCK_ID,
         UtilityEnum.OPEN_BUTTON_ACTION_ID,
         appId,
-        "Open",
+        `Edit board`,
         ButtonStyle.PRIMARY,
         boardURL
     );

--- a/whiteboard/blocks/UtilityBlock.ts
+++ b/whiteboard/blocks/UtilityBlock.ts
@@ -122,7 +122,7 @@ export async function permissionHeaderBlock(
 
     let markdownBlock: SectionBlock;
         markdownBlock = getMarkdownBlock(
-            `${username} wants to edit *${boardname}*`
+            `${userForBoardPermission} wants to edit *${boardname}*`
         );
 
     const actionBlock = getActionsBlock(UtilityEnum.PERMISSION_BLOCK_ID, [

--- a/whiteboard/blocks/UtilityBlock.ts
+++ b/whiteboard/blocks/UtilityBlock.ts
@@ -91,3 +91,43 @@ export async function deletionHeaderBlock(
     block.push(deletionBlock);
     return block;
 }
+
+// Header block for boardOwners to give permissions to the user
+export async function permissionHeaderBlock(
+    username: string,
+    boardname: string,
+    appId: string,
+): Promise<Array<Block>> {
+    const block: Block[] = [];
+
+    const grantPermissionButton = getButton(
+        "Edit board",
+        UtilityEnum.PREVIEW_BLOCK_ID,
+        UtilityEnum.OPEN_BUTTON_ACTION_ID,
+        appId,
+        "Open",
+        ButtonStyle.PRIMARY
+    );
+
+    const denyPermissionButton = getButton(
+        "Settings",
+        UtilityEnum.PREVIEW_BLOCK_ID,
+        UtilityEnum.SETTINGS_BUTTON_ACTION_ID,
+        appId,
+        "Settings",
+        undefined
+    );
+
+    let markdownBlock: SectionBlock;
+        markdownBlock = getMarkdownBlock(
+            `${username} wants to edit *${boardname}*`
+        );
+
+    const actionBlock = getActionsBlock(UtilityEnum.PREVIEW_BLOCK_ID, [
+        grantPermissionButton,
+        denyPermissionButton
+    ]);
+    block.push(markdownBlock);
+    block.push(actionBlock);
+    return block;
+}

--- a/whiteboard/enum/uitlityEnum.ts
+++ b/whiteboard/enum/uitlityEnum.ts
@@ -50,4 +50,10 @@ export enum UtilityEnum {
     YES = "Yes",
     YES_BLOCK_ID = "yes-block-id",
     YES_ACTION_ID = "yes-action-id",
+
+    PERMISSION_BLOCK_ID = "permission-block-id",
+    ALLOW_BLOCK_ID = "allow-block-id",
+    ALLOW_BUTTON_ACTION_ID = "allow_button_action_id",
+    DENY_BLOCK_ID = "deny-block-id",
+    DENY_BUTTON_ACTION_ID = "deny_button_action_id",
 }

--- a/whiteboard/enum/uitlityEnum.ts
+++ b/whiteboard/enum/uitlityEnum.ts
@@ -40,4 +40,14 @@ export enum UtilityEnum {
     DELETE_ACTION_ID = "delete-action-id",
     DELETE_BLOCK_ID = "delete-block-id",
     NAME_ALREADY_EXISTS = "Name already exists. Try different name",
+
+    PERMISSION_DESC = "You don't have permission to edit or delete this whiteboard. Do you want to request permission?",
+    PERMISSION_MODAL_ID = "permission-modal-id",
+    PERMISSION_DENIED = "Permission Denied",   
+    NO = "No",
+    NO_BLOCK_ID = "no-block-id",
+    NO_ACTION_ID = "no-action-id",
+    YES = "Yes",
+    YES_BLOCK_ID = "yes-block-id",
+    YES_ACTION_ID = "yes-action-id",
 }

--- a/whiteboard/enum/uitlityEnum.ts
+++ b/whiteboard/enum/uitlityEnum.ts
@@ -41,6 +41,14 @@ export enum UtilityEnum {
     DELETE_BLOCK_ID = "delete-block-id",
     NAME_ALREADY_EXISTS = "Name already exists. Try different name",
 
+    EDIT = "Edit",
+    EDIT_DESC = "Do you want to edit this whiteboard?",
+    EDIT_MODAL_ID = "edit-modal-id",   
+    NO_EDIT_BLOCK_ID = "no-edit-block-id",
+    NO_EDIT_ACTION_ID = "no-edit-action-id",
+    YES_EDIT_BLOCK_ID = "yes-edit-block-id",
+    YES_EDIT_ACTION_ID = "yes-edit-action-id",
+
     PERMISSION_DESC = "You don't have permission to edit or delete this whiteboard. Do you want to request permission?",
     PERMISSION_MODAL_ID = "permission-modal-id",
     PERMISSION_DENIED = "Permission Denied",   

--- a/whiteboard/handlers/ExecuteActionButtonHandler.ts
+++ b/whiteboard/handlers/ExecuteActionButtonHandler.ts
@@ -32,7 +32,6 @@ export class ExecuteActionButtonHandler {
 
         try {
             const { actionId } = data;
-            console.log("actionId", actionId)
             switch (actionId) {
                 // handleCreateWhiteboardButtonAction is used to handle the create whiteboard button action
                 case UtilityEnum.CREATE_WHITEBOARD_MESSAGE_BOX_ACTION_ID:

--- a/whiteboard/handlers/ExecuteActionButtonHandler.ts
+++ b/whiteboard/handlers/ExecuteActionButtonHandler.ts
@@ -32,6 +32,7 @@ export class ExecuteActionButtonHandler {
 
         try {
             const { actionId } = data;
+            console.log("actionId", actionId)
             switch (actionId) {
                 // handleCreateWhiteboardButtonAction is used to handle the create whiteboard button action
                 case UtilityEnum.CREATE_WHITEBOARD_MESSAGE_BOX_ACTION_ID:

--- a/whiteboard/handlers/ExecuteBlockActionHandler.ts
+++ b/whiteboard/handlers/ExecuteBlockActionHandler.ts
@@ -18,6 +18,7 @@ import { addUsertoBoardOwner, hasPermission } from "../lib/messages";
 import { PermissionModal } from '../modals/PermissionModal';
 import { IMessage } from "@rocket.chat/apps-engine/definition/messages";
 import { RocketChatAssociationModel, RocketChatAssociationRecord } from "@rocket.chat/apps-engine/definition/metadata";
+import { EditModal } from "../modals/EditModal";
 
 // ExecuteBlockActionHandler is used to handle the block actions
 export class ExecuteBlockActionHandler {
@@ -99,6 +100,35 @@ export class ExecuteBlockActionHandler {
                             ]);
                         }
 
+                        return this.context
+                            .getInteractionResponder()
+                            .successResponse();
+                        
+                    case UtilityEnum.YES_ACTION_ID:
+                        return this.context
+                            .getInteractionResponder()
+                            .successResponse();
+
+                    case UtilityEnum.OPEN_BUTTON_ACTION_ID:
+                        const boardData = this.context.getInteractionData().value
+                        const interactionData = this.context.getInteractionData();
+                        console.log("boardData in open_button_action_id", boardData, interactionData)
+                        const boardURL = boardData?.split(",")[0].trim();
+                        const interactionBoardName = boardData?.split(",")[1].trim();
+                        console.log("boardURL", boardURL)
+                        if (boardURL && messageId && interactionBoardName) {
+                            const modal = await EditModal(appId, boardURL, messageId, interactionBoardName);
+                            await Promise.all([
+                                this.modify.getUiController().openSurfaceView(
+                                    modal,
+                                    {
+                                        triggerId,
+                                    },
+                                    user
+                                ),
+                            ]);
+                            
+                        }
                         return this.context
                             .getInteractionResponder()
                             .successResponse();

--- a/whiteboard/handlers/ExecuteBlockActionHandler.ts
+++ b/whiteboard/handlers/ExecuteBlockActionHandler.ts
@@ -43,8 +43,6 @@ export class ExecuteBlockActionHandler {
                 container,
             } = data;
 
-            // console.log("data", data)
-            // const appSender = this.app;
             const read = this.read;
             const appId = data.appId;
             // The id of the message (created when the user created the whiteboard)
@@ -55,18 +53,12 @@ export class ExecuteBlockActionHandler {
 
             let boolean = true
             if (messageId) {
-                boolean = await hasPermission(user, room, read, messageId, this.modify, this.context)
+                boolean = await hasPermission(user, read, messageId)
             }
 
 
             if (boolean) {
                 switch (actionId) {
-                    // case UtilityEnum.OPEN_BUTTON_ACTION_ID:
-                    //     if(messageId && room){
-                    //         const messageNew:IMessage = {room: room, sender: appSender, text:"Permission not allowed!"}
-                    //         this.modify.getNotifier().notifyUser(user, messageNew)
-                    //     }
-                    // handleSettingsButtonAction is used to handle the settings button action
                     case UtilityEnum.SETTINGS_BUTTON_ACTION_ID:
                         if (messageId) {
                             const modal = await SettingsModal(appId, messageId);
@@ -86,7 +78,7 @@ export class ExecuteBlockActionHandler {
 
                     // Add the case for the delete button action
                     case UtilityEnum.DELETE_BUTTON_ACTION_ID:
-                        console.log("delete_button_action_id", messageId)
+  
                         if (messageId) {
                             const modal = await DeleteModal(appId, messageId);
                             await Promise.all([
@@ -111,11 +103,10 @@ export class ExecuteBlockActionHandler {
 
                     case UtilityEnum.OPEN_BUTTON_ACTION_ID:
                         const boardData = this.context.getInteractionData().value
-                        const interactionData = this.context.getInteractionData();
-                        console.log("boardData in open_button_action_id", boardData, interactionData)
+                        
                         const boardURL = boardData?.split(",")[0].trim();
                         const interactionBoardName = boardData?.split(",")[1].trim();
-                        console.log("boardURL", boardURL)
+                        
                         if (boardURL && messageId && interactionBoardName) {
                             const modal = await EditModal(appId, boardURL, messageId, interactionBoardName);
                             await Promise.all([
@@ -135,7 +126,6 @@ export class ExecuteBlockActionHandler {
                     
                     case UtilityEnum.ALLOW_BUTTON_ACTION_ID:
                         const data = this.context.getInteractionData();
-                        // console.log("data", data)
                         const userName = data.value?.split(",")[0].trim();
                         const boardName = data.value?.split(",")[1].trim();
                         const userForBoardPermission = data.value?.split(",")[2].trim();
@@ -145,24 +135,17 @@ export class ExecuteBlockActionHandler {
                             `${permissionMessageId}#MessageId`
                         );
                         const messageRead = await read.getPersistenceReader().readByAssociation(messageAssociation)
-                        console.log("messageRead", messageRead)
-                        // console.log("names ", userName, boardName)
                         if(room && userName && boardName && userForBoardPermission){
                             const userForBoardPermissionData = await addUsertoBoardOwner(this.read, room, this.persistence, userName.trim(), boardName, userForBoardPermission, "allow")
                             const boardOwnerData = await read.getUserReader().getByUsername(userName)
                             const message:IMessage = {text:`Permission granted for board ${boardName}`, room:room, sender: appSender} 
                             if(userForBoardPermissionData){
                                 this.modify.getNotifier().notifyUser(userForBoardPermissionData, message)
-                                // this.modify.getUpdater().message(permissionMessageId, boardOwnerData)
                             }
                             else{
                                 console.log("UserData", userForBoardPermissionData)
                             }
-
-                            
-                            // const messageToOwners:IMessage = {text:"Permission granted", room:room, sender: appSender} 
-
-                            
+                         
                         }
                         
                         return this.context
@@ -170,9 +153,7 @@ export class ExecuteBlockActionHandler {
                             .successResponse();
 
                     case UtilityEnum.DENY_BUTTON_ACTION_ID:
-                        // const data = this.context.getInteractionData();
-                        // const userName = data.value?.split(",")[0];
-                        // const boardName = data.value?.split(",")[1];
+                       
                         if(room && userName && boardName && userForBoardPermission){
                             const userData = await addUsertoBoardOwner(this.read, room, this.persistence, userName.trim(), boardName.trim(), userForBoardPermission.trim(), "deny")
     
@@ -198,10 +179,7 @@ export class ExecuteBlockActionHandler {
             }
             else {
                 if (messageId) {
-                    // const messageIdNew =
-                    //         this.context.getInteractionData()
-
-                    // console.log("messageIdNew", messageIdNew)
+                    
                     const modal = await PermissionModal(appId, messageId);
                     await Promise.all([
                         this.modify.getUiController().openSurfaceView(

--- a/whiteboard/handlers/ExecuteBlockActionHandler.ts
+++ b/whiteboard/handlers/ExecuteBlockActionHandler.ts
@@ -14,6 +14,7 @@ import { UtilityEnum } from "../enum/uitlityEnum";
 import { SettingsModal } from "../modals/SettingsModal";
 import { DeleteModal } from "../modals/DeleteModal";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { hasPermission } from "../lib/messages";
 
 // ExecuteBlockActionHandler is used to handle the block actions
 export class ExecuteBlockActionHandler {
@@ -38,13 +39,17 @@ export class ExecuteBlockActionHandler {
                 container,
             } = data;
 
-            const appSender = this.app;
+            // const appSender = this.app;
+            const read = this.read;
             const appId = data.appId;
             // The id of the message (created when the user created the whiteboard)
             const messageId = data.message?.id;
-            const AppSender: IUser = (await this.read
+            const appSender: IUser = (await this.read
                 .getUserReader()
                 .getAppUser()) as IUser;
+
+            console.log("actionId", actionId);
+            await hasPermission(appSender, room, read, messageId)
             switch (actionId) {
                 // handleSettingsButtonAction is used to handle the settings button action
                 case UtilityEnum.SETTINGS_BUTTON_ACTION_ID:

--- a/whiteboard/handlers/ExecuteViewSubmitHandler.ts
+++ b/whiteboard/handlers/ExecuteViewSubmitHandler.ts
@@ -47,6 +47,7 @@ export class ExecuteViewSubmitHandler {
             .getAppUser()) as IUser;
         const appId = AppSender.appId;
         try {
+            console.log("View Id: ", view);
             switch (view.id) {
                 // This case is used to handle the submit interaction from the settings modal
                 case UtilityEnum.SETTINGS_MODAL_ID:

--- a/whiteboard/handlers/ExecuteViewSubmitHandler.ts
+++ b/whiteboard/handlers/ExecuteViewSubmitHandler.ts
@@ -25,7 +25,7 @@ import {
     checkBoardNameByRoomId,
 } from "../persistence/boardInteraction";
 import { getDirect, sendMessage } from "../lib/messages";
-import { IMessageAttachment } from "@rocket.chat/apps-engine/definition/messages";
+import { IMessage, IMessageAttachment } from "@rocket.chat/apps-engine/definition/messages";
 import { AppEnum } from "../enum/App";
 
 //This class will handle all the view submit interactions from the modals
@@ -360,6 +360,38 @@ export class ExecuteViewSubmitHandler {
                         .getInteractionResponder()
                         .successResponse();
 
+                        case UtilityEnum.PERMISSION_MODAL_ID:
+                            const messageId =
+                            this.context.getInteractionData().view.submit
+                                ?.value;
+                             if(messageId){
+
+                                 const room = await this.read
+                                     .getMessageReader()
+                                     .getRoom(messageId);
+                                     if(room){
+                                //   console.log("Checking interaction data", this.context.getInteractionData().view.submit?.value)
+                                  const boardMessageId = this.context.getInteractionData().view.submit?.value
+                                  if(boardMessageId){
+                                      const boardData = await getBoardRecordByMessageId(this.read.getPersistenceReader(), boardMessageId)
+                                        console.log("Board data", boardData)
+                                        for(let i=0; i<boardData.boardOwner.length; i++){
+                                            const user = boardData.boardOwner[i]
+                                            if(user){
+                                                const message:IMessage = {text:"Hello", room: room, sender: this.context.getInteractionData().user}
+                                                this.modify.getNotifier().notifyUser(user, message)
+                                            }
+                                        }
+                                  }
+                                  
+                                
+                                    // const message:IMessage = {text:"Hello", room: room, sender: this.context.getInteractionData().user}
+                                    // this.modify.getNotifier().notifyUser(user, message)
+
+                                }
+                             }   
+                            return this.context.getInteractionResponder().successResponse();
+                        
                 default:
                     console.log("View Id not found");
                     return this.context
@@ -572,3 +604,6 @@ export class ExecuteViewSubmitHandler {
         await this.modify.getUpdater().finish(privateMessage);
     }
 }
+
+
+// 

--- a/whiteboard/handlers/ExecuteViewSubmitHandler.ts
+++ b/whiteboard/handlers/ExecuteViewSubmitHandler.ts
@@ -47,7 +47,7 @@ export class ExecuteViewSubmitHandler {
             .getAppUser()) as IUser;
         const appId = AppSender.appId;
         try {
-            console.log("View Id: ", view);
+            // console.log("View Id: ", view);
             switch (view.id) {
                 // This case is used to handle the submit interaction from the settings modal
                 case UtilityEnum.SETTINGS_MODAL_ID:
@@ -315,7 +315,7 @@ export class ExecuteViewSubmitHandler {
                         const messageId =
                             this.context.getInteractionData().view.submit
                                 ?.value;
-
+                        // console.log("MessageId inside Delete Modal ID", messageId)
                         if (messageId) {
                             // Board data is deleted from database
                             const boardName = await deleteBoardByMessageId(
@@ -374,30 +374,36 @@ export class ExecuteViewSubmitHandler {
                                   const boardMessageId = this.context.getInteractionData().view.submit?.value
                                   if(boardMessageId){
                                       const boardData = await getBoardRecordByMessageId(this.read.getPersistenceReader(), boardMessageId)
-                                        console.log("Board data", boardData)
+                                        // console.log("Board data", boardData)
                                         for(let i=0; i<boardData.boardOwner.length; i++){
-                                            const user = boardData.boardOwner[i]
-                                            if(user && appId){
+                                            const userBoardOwner = boardData.boardOwner[i]
+                                            if(userBoardOwner && appId){
                                                 const boardName = boardData.title;
-                                                const message = await this.modify
-                                                .getUpdater()
-                                                .message(messageId, AppSender);
+                                                // const message = await this.modify
+                                                // .getUpdater()
+                                                // .message(messageId, AppSender);
+                                                const message = this.modify.getCreator().startMessage();
+                                                const userBoardPermission = this.context.getInteractionData().user;
+
+                                                
+                                                // console.log("board_permission_kaun_le_rha_viewsubmithandler.ts", this.context.getInteractionData())
             
-                                            // Deletion header block as board get deleted
+                                            // Permission header block as other user is trying to edit the board
                                             const permissionBlock =
                                                 await permissionHeaderBlock(
-                                                    user.username,
+                                                    userBoardOwner.username,
+                                                    userBoardPermission.username,
                                                     boardName,
                                                     appId
                                                 );
             
                                             // Some message configurations
-                                            message.setEditor(user).setRoom(room);
+                                            message.setEditor(userBoardOwner).setRoom(room);
                                             message.setBlocks(permissionBlock);
-                                            message.removeAttachment(0);
+                                            // message.removeAttachment(0);
             
                                             // Message is finished modified and saved to database
-                                            await this.modify.getNotifier().notifyUser(user, message.getMessage());
+                                            await this.modify.getNotifier().notifyUser(userBoardOwner, message.getMessage());
                                                 // const message:IMessage = {text:"Hello", room: room, sender: this.context.getInteractionData().user}
                                                 // this.modify.getNotifier().notifyUser(user, message)
                                             }
@@ -411,6 +417,8 @@ export class ExecuteViewSubmitHandler {
                                 }
                              }   
                             return this.context.getInteractionResponder().successResponse();
+
+                        // case UtilityEnum.ALLOW_MODAL_ID
                         
                 default:
                     console.log("View Id not found");

--- a/whiteboard/handlers/ExecuteViewSubmitHandler.ts
+++ b/whiteboard/handlers/ExecuteViewSubmitHandler.ts
@@ -13,7 +13,7 @@ import {
 import { UIKitBlockInteractionContext } from "@rocket.chat/apps-engine/definition/uikit";
 import { UtilityEnum } from "../enum/uitlityEnum";
 import { IUser } from "@rocket.chat/apps-engine/definition/users/IUser";
-import { buildHeaderBlock, deletionHeaderBlock } from "../blocks/UtilityBlock";
+import { buildHeaderBlock, deletionHeaderBlock, permissionHeaderBlock } from "../blocks/UtilityBlock";
 import {
     getBoardRecordByMessageId,
     getMessageIdByPrivateMessageId,
@@ -377,9 +377,29 @@ export class ExecuteViewSubmitHandler {
                                         console.log("Board data", boardData)
                                         for(let i=0; i<boardData.boardOwner.length; i++){
                                             const user = boardData.boardOwner[i]
-                                            if(user){
-                                                const message:IMessage = {text:"Hello", room: room, sender: this.context.getInteractionData().user}
-                                                this.modify.getNotifier().notifyUser(user, message)
+                                            if(user && appId){
+                                                const boardName = boardData.title;
+                                                const message = await this.modify
+                                                .getUpdater()
+                                                .message(messageId, AppSender);
+            
+                                            // Deletion header block as board get deleted
+                                            const permissionBlock =
+                                                await permissionHeaderBlock(
+                                                    user.username,
+                                                    boardName,
+                                                    appId
+                                                );
+            
+                                            // Some message configurations
+                                            message.setEditor(user).setRoom(room);
+                                            message.setBlocks(permissionBlock);
+                                            message.removeAttachment(0);
+            
+                                            // Message is finished modified and saved to database
+                                            await this.modify.getNotifier().notifyUser(user, message.getMessage());
+                                                // const message:IMessage = {text:"Hello", room: room, sender: this.context.getInteractionData().user}
+                                                // this.modify.getNotifier().notifyUser(user, message)
                                             }
                                         }
                                   }

--- a/whiteboard/handlers/ExecuteViewSubmitHandler.ts
+++ b/whiteboard/handlers/ExecuteViewSubmitHandler.ts
@@ -313,16 +313,15 @@ export class ExecuteViewSubmitHandler {
                     if (view.state && appId) {
 
                         const boardData = this.context.getInteractionData().view.submit?.value
-                        const interactionData = this.context.getInteractionData().view
-                        console.log("interactionData", interactionData)
+                        
                         if(boardData){
-                            console.log("boardData in edit_modal_id", boardData)
+                            
                             const messageId = boardData?.split(",")[0].trim()
                             const boardName = boardData?.split(",")[1].trim()
                             const boardURL =
                                 this.context.getInteractionData().view.submit
                                     ?.url;
-                            // console.log("MessageId inside Edit Modal ID", messageId)
+
                             if (messageId) {
     
                                 // Message is Updated to "Deletion"

--- a/whiteboard/helpers/blockBuilder.ts
+++ b/whiteboard/helpers/blockBuilder.ts
@@ -100,6 +100,18 @@ export function getButton(
     return button;
 }
 
+export function getEditBlock(
+    blockId: string,
+    elements: Array<ButtonElement> | Array<StaticSelectElement>
+) {
+    const block: ActionsBlock = {
+        type: "actions",
+        blockId,
+        elements,
+    };
+    return block;
+}
+
 export function getSectionBlock(labelText: string, accessory?: any) {
     const block: SectionBlock = {
         type: "section",

--- a/whiteboard/lib/commandUtility.ts
+++ b/whiteboard/lib/commandUtility.ts
@@ -31,6 +31,7 @@ import {
     getMessageIdByBoardName,
     deleteBoardByMessageId,
 } from "../persistence/boardInteraction";
+import { IMessage } from "@rocket.chat/apps-engine/definition/messages";
 //CommandUtility is used to handle the commands
 
 export class CommandUtility implements ExecutorProps {
@@ -73,6 +74,8 @@ export class CommandUtility implements ExecutorProps {
         const boardEndpoint = endpoints[0];
         const appId = app.getID();
         const params = this.context.getArguments();
+
+        const boardOwner = [sender]
 
         // the name specified in command "/whiteboard new"
         let createBoardName =
@@ -140,6 +143,8 @@ export class CommandUtility implements ExecutorProps {
                         headerBlock
                     );
 
+                    console.log("MessageId", messageId);
+
                     storeBoardRecord(
                         persistence,
                         room.id,
@@ -153,7 +158,8 @@ export class CommandUtility implements ExecutorProps {
                         "",
                         name,
                         "",
-                        "Public"
+                        "Public",
+                        boardOwner
                     );
                 }
             }
@@ -303,6 +309,27 @@ export class CommandUtility implements ExecutorProps {
         }
     }
 
+    // private async checkCommand() {
+    //     const appId = this.app.getID();
+    //     const user = this.context.getSender();
+    //     const params = this.context.getArguments();
+    //     const room: IRoom = this.context.getRoom();
+    //     const appSender: IUser = (await this.read
+    //         .getUserReader()
+    //         .getAppUser()) as IUser;
+    //         const attachments = [
+    //             {
+    //                 collapsed: true,
+    //                 color: "#00000000",
+    //                 imageUrl: defaultPreview,
+    //             },
+    //         ];
+
+    //     const message:IMessage = {text:"Board Here", room:room, sender:appSender, pinned:true, attachments:attachments}
+
+    //     await this.read.getNotifier().notifyRoom(room, message);
+    // }
+
     public async resolveCommand(context: WhiteboardSlashCommandContext) {
         switch (this.command[0]) {
             case "new":
@@ -317,6 +344,9 @@ export class CommandUtility implements ExecutorProps {
             case "delete":
                 await this.deleteBoardCommand();
                 break;
+            // case "check":
+            //     await this.checkCommand();
+            //     break;
             default:
                 const appSender: IUser = (await this.read
                     .getUserReader()

--- a/whiteboard/lib/commandUtility.ts
+++ b/whiteboard/lib/commandUtility.ts
@@ -81,10 +81,15 @@ export class CommandUtility implements ExecutorProps {
         const users =  await read.getRoomReader().getMembers(room.id)
         for(const user of users){
             if(user.roles.includes('admin') || user.roles.includes('owner') || user.roles.includes('moderator')){
-                boardOwner.push(user)
+                if(sender.username != user.username){
+                
+                    // console.log("here again", user, sender.username)
+                    boardOwner.push(user)
+                }
+
             }
         }
-        
+
         // the name specified in command "/whiteboard new"
         let createBoardName =
             params.length > 1 ? params.slice(1).join(" ") : "";

--- a/whiteboard/lib/commandUtility.ts
+++ b/whiteboard/lib/commandUtility.ts
@@ -15,7 +15,7 @@ import {
     sendMessage,
     sendMessageWithAttachment,
 } from "./messages";
-import { buildHeaderBlock, deletionHeaderBlock } from "../blocks/UtilityBlock";
+import { buildHeaderBlock, buildHeaderBlockAfterPermission, deletionHeaderBlock } from "../blocks/UtilityBlock";
 import { WhiteboardSlashCommandContext } from "../commands/WhiteboardCommand";
 import {
     deleteBoards,
@@ -140,6 +140,7 @@ export class CommandUtility implements ExecutorProps {
                         appId,
                         name
                     );
+
                     const attachments = [
                         {
                             collapsed: true,
@@ -157,6 +158,22 @@ export class CommandUtility implements ExecutorProps {
                     );
 
                     console.log("MessageId", messageId);
+
+                    // const headerBlockAfterPermission = await buildHeaderBlockAfterPermission(
+                    //     sender.username,
+                    //     boardURL,
+                    //     appId,
+                    //     name
+                    // )
+                    // const message = await this.modify
+                    //                     .getUpdater()
+                    //                     .message(messageId, sender);
+                    // message.setBlocks(headerBlockAfterPermission)
+                    // for(let user of boardOwner){
+
+                    //     await this.modify.getNotifier().notifyUser(user, message.getMessage());
+                    //     // await this.modify.getUpdater().finish(message);
+                    // }
 
                     storeBoardRecord(
                         persistence,

--- a/whiteboard/lib/commandUtility.ts
+++ b/whiteboard/lib/commandUtility.ts
@@ -76,7 +76,15 @@ export class CommandUtility implements ExecutorProps {
         const params = this.context.getArguments();
 
         const boardOwner = [sender]
-
+        
+        // check the roomAdmin
+        const users =  await read.getRoomReader().getMembers(room.id)
+        for(const user of users){
+            if(user.roles.includes('admin') || user.roles.includes('owner') || user.roles.includes('moderator')){
+                boardOwner.push(user)
+            }
+        }
+        
         // the name specified in command "/whiteboard new"
         let createBoardName =
             params.length > 1 ? params.slice(1).join(" ") : "";

--- a/whiteboard/lib/messages.ts
+++ b/whiteboard/lib/messages.ts
@@ -13,6 +13,7 @@ import {
     getBoardRecordByMessageId,
     getBoardRecordByRoomId,
     getBoardRecordByRoomIdandBoardId,
+    storeBoardRecord,
 } from "../persistence/boardInteraction";
 import { IMessage } from "@rocket.chat/apps-engine/definition/messages";
 import { RocketChatAssociationModel, RocketChatAssociationRecord } from '@rocket.chat/apps-engine/definition/metadata';
@@ -276,27 +277,36 @@ export async function hasPermission(
     modify: IModify,
     context: any
 ) {
-    console.log("messageId", messageId)
-    console.log("user", user)
+    // console.log("messageId", messageId)
+    // console.log("user_hasPermission", user)
     // console.log("room", room)
     // console.log("triggerString", triggerId)
+    if(room){
+        const boardDataInRoom = await getBoardRecordByRoomId(read.getPersistenceReader(), room.id)
+        console.log("boardDataInRoom", boardDataInRoom)
+    }
+
 
     // Get the board data from the database
     const boardData = await getBoardRecordByMessageId(read.getPersistenceReader(), messageId)
 
-    // console.log("boardData", boardData)
+    console.log("boardData_hasPermission", boardData.boardOwner)
 
     // Check whethet boardData.boardOwner contains user
     let checkBoolean = false;
     for (let i = 0; i < boardData.boardOwner.length; i++) {
-        console.log("boardOwner", boardData.boardOwner[i])
+        // console.log("boardOwner_hasPermission", boardData.boardOwner[i], user)
         if (boardData.boardOwner[i].id === user.id) {
             checkBoolean = true;
             break;
         }
     }
 
-    console.log("checkBoolean", checkBoolean)
+    if(user.roles.includes("admin") || user.roles.includes("owner") || user.roles.includes("moderator")){
+        checkBoolean = true
+    }
+
+    // console.log("checkBoolean", checkBoolean)
     // If checkBoolean is false then ask the user for permision
     if (checkBoolean === false) {
         return false 
@@ -305,4 +315,81 @@ export async function hasPermission(
     return true
 
     // If checkBoolean is true then allow user to perform the action
+}
+
+export async function addUsertoBoardOwner(
+    read: IRead,
+    room: IRoom,
+    persistance: IPersistence,
+    userName: string,
+    boardName: string,
+    userNameForBoardPermission: string,
+    permission: string
+){
+    if(permission==="allow"){
+        // Get the user data from the database
+        const userData = await read.getUserReader().getByUsername(userName)
+
+        const userForBoardPermission = await read.getUserReader().getByUsername(userNameForBoardPermission)
+    
+        // Get the board data from the database
+        const boardData = await getBoardRecordByRoomId(read.getPersistenceReader(), room.id)
+        let requiredBoardData;
+        for (let i = 0; i < boardData.length; i++) {
+            // console.log("boardData boolean check", boardData[i].title, boardName, boardData[i].title==boardName)
+            if (boardData[i].title == boardName) {
+                requiredBoardData = boardData[i]
+                break;
+            }
+        }
+        // Add the user to the boardOwner
+        const boardOwnerArray = [ userForBoardPermission ]
+        // console.log("boardOwner length", requiredBoardData)
+        for(let i=0;i<requiredBoardData.boardOwner.length;i++){
+            boardOwnerArray.push(requiredBoardData.boardOwner[i])
+        }
+
+        // console.log("boardDataArray ", boardOwnerArray)
+
+        // console.log("BoardData ", boardData)
+
+    // persistence: IPersistence,
+    // roomId: string,
+    // boardId: string,
+    // boardData: any,
+    // messageId: string,
+    // cover: string,
+    // title: string,
+    // privateMessageId: string,
+    // status: string,
+    // boardOwner?: IUser[]
+
+    console.log("boardDataCheck", requiredBoardData)
+
+    // Update the boardData in the database
+    const recordId = await storeBoardRecord(
+        persistance,
+        room.id,
+        requiredBoardData.id,
+        requiredBoardData.boardData,
+        requiredBoardData.messageId,
+        requiredBoardData.cover,
+        requiredBoardData.title,
+        requiredBoardData.privateMessageId,
+        requiredBoardData.status,
+        boardOwnerArray
+        )
+    console.log("recordId", recordId)
+
+    return userForBoardPermission
+    }
+    else if(permission==="deny"){
+        const userForBoardPermission = await read.getUserReader().getByUsername(userNameForBoardPermission)
+        return userForBoardPermission
+    }
+
+    else{
+        console.log("Error has occured! ", read, room, userName, boardName, userNameForBoardPermission, permission)
+        return undefined
+    }
 }

--- a/whiteboard/lib/messages.ts
+++ b/whiteboard/lib/messages.ts
@@ -14,6 +14,7 @@ import {
     getBoardRecordByRoomIdandBoardId,
 } from "../persistence/boardInteraction";
 import { IMessage } from "@rocket.chat/apps-engine/definition/messages";
+import {RocketChatAssociationModel, RocketChatAssociationRecord} from '@rocket.chat/apps-engine/definition/metadata';
 
 // getDirect is used to get the direct room between the app user and the user
 
@@ -260,4 +261,39 @@ export async function deleteMessage(
     } catch (error) {
         console.error(`Error deleting message: ${error}`);
     }
+}
+
+// Function to check if the user has rights or not
+export async function hasPermission(
+    user: IUser,
+    room: IRoom | undefined,
+    read: IRead,
+    messageId: string | undefined
+) {
+    console.log("messageId", messageId)
+    console.log("user", user)
+    console.log("room", room)
+
+    let checkBoolean = false;
+    if (user.roles.includes("admin")) {
+        checkBoolean = true;
+    }
+
+    const roomAssociation = new RocketChatAssociationRecord(
+        RocketChatAssociationModel.ROOM,
+        `${room?.id}#BoardName`
+    );
+
+    const roomRecord = await read.getPersistenceReader().readByAssociation(roomAssociation)
+
+    // console.log("roomRecord", roomRecord)
+
+    const messageAssociation = new RocketChatAssociationRecord(
+        RocketChatAssociationModel.MESSAGE,
+        `${messageId}#MessageId`
+    );
+
+    const messageRecord = await read.getPersistenceReader().readByAssociation(messageAssociation)
+    
+    console.log("messageRecord", messageRecord)
 }

--- a/whiteboard/lib/messages.ts
+++ b/whiteboard/lib/messages.ts
@@ -283,14 +283,14 @@ export async function hasPermission(
     // console.log("triggerString", triggerId)
     if(room){
         const boardDataInRoom = await getBoardRecordByRoomId(read.getPersistenceReader(), room.id)
-        console.log("boardDataInRoom", boardDataInRoom)
+        // console.log("boardDataInRoom", boardDataInRoom)
     }
 
 
     // Get the board data from the database
     const boardData = await getBoardRecordByMessageId(read.getPersistenceReader(), messageId)
 
-    console.log("boardData_hasPermission", boardData.boardOwner)
+    // console.log("boardData_hasPermission", boardData.boardOwner)
 
     // Check whethet boardData.boardOwner contains user
     let checkBoolean = false;

--- a/whiteboard/lib/messages.ts
+++ b/whiteboard/lib/messages.ts
@@ -271,31 +271,17 @@ export async function deleteMessage(
 // Function to check if the user has rights or not
 export async function hasPermission(
     user: IUser,
-    room: IRoom | undefined,
     read: IRead,
     messageId: string,
-    modify: IModify,
-    context: any
 ) {
-    // console.log("messageId", messageId)
-    // console.log("user_hasPermission", user)
-    // console.log("room", room)
-    // console.log("triggerString", triggerId)
-    if(room){
-        const boardDataInRoom = await getBoardRecordByRoomId(read.getPersistenceReader(), room.id)
-        // console.log("boardDataInRoom", boardDataInRoom)
-    }
-
 
     // Get the board data from the database
     const boardData = await getBoardRecordByMessageId(read.getPersistenceReader(), messageId)
 
-    // console.log("boardData_hasPermission", boardData.boardOwner)
 
     // Check whethet boardData.boardOwner contains user
     let checkBoolean = false;
     for (let i = 0; i < boardData.boardOwner.length; i++) {
-        // console.log("boardOwner_hasPermission", boardData.boardOwner[i], user)
         if (boardData.boardOwner[i].id === user.id) {
             checkBoolean = true;
             break;
@@ -306,15 +292,14 @@ export async function hasPermission(
         checkBoolean = true
     }
 
-    // console.log("checkBoolean", checkBoolean)
     // If checkBoolean is false then ask the user for permision
     if (checkBoolean === false) {
         return false 
     }
 
+    // If checkBoolean is true then allow user to perform the action
     return true
 
-    // If checkBoolean is true then allow user to perform the action
 }
 
 export async function addUsertoBoardOwner(
@@ -328,15 +313,12 @@ export async function addUsertoBoardOwner(
 ){
     if(permission==="allow"){
         // Get the user data from the database
-        const userData = await read.getUserReader().getByUsername(userName)
-
         const userForBoardPermission = await read.getUserReader().getByUsername(userNameForBoardPermission)
     
         // Get the board data from the database
         const boardData = await getBoardRecordByRoomId(read.getPersistenceReader(), room.id)
         let requiredBoardData;
         for (let i = 0; i < boardData.length; i++) {
-            // console.log("boardData boolean check", boardData[i].title, boardName, boardData[i].title==boardName)
             if (boardData[i].title == boardName) {
                 requiredBoardData = boardData[i]
                 break;
@@ -344,30 +326,12 @@ export async function addUsertoBoardOwner(
         }
         // Add the user to the boardOwner
         const boardOwnerArray = [ userForBoardPermission ]
-        // console.log("boardOwner length", requiredBoardData)
         for(let i=0;i<requiredBoardData.boardOwner.length;i++){
             boardOwnerArray.push(requiredBoardData.boardOwner[i])
         }
 
-        // console.log("boardDataArray ", boardOwnerArray)
-
-        // console.log("BoardData ", boardData)
-
-    // persistence: IPersistence,
-    // roomId: string,
-    // boardId: string,
-    // boardData: any,
-    // messageId: string,
-    // cover: string,
-    // title: string,
-    // privateMessageId: string,
-    // status: string,
-    // boardOwner?: IUser[]
-
-    console.log("boardDataCheck", requiredBoardData)
-
     // Update the boardData in the database
-    const recordId = await storeBoardRecord(
+    await storeBoardRecord(
         persistance,
         room.id,
         requiredBoardData.id,
@@ -379,7 +343,6 @@ export async function addUsertoBoardOwner(
         requiredBoardData.status,
         boardOwnerArray
         )
-    console.log("recordId", recordId)
 
     return userForBoardPermission
     }

--- a/whiteboard/modals/EditModal.ts
+++ b/whiteboard/modals/EditModal.ts
@@ -1,0 +1,91 @@
+import {
+    ButtonStyle,
+    UIKitSurfaceType,
+} from "@rocket.chat/apps-engine/definition/uikit";
+import { IUIKitSurfaceViewParam } from "@rocket.chat/apps-engine/definition/accessors";
+import { UtilityEnum } from "../enum/uitlityEnum";
+import {Block, Option, InputBlock, SectionBlock} from '@rocket.chat/ui-kit';
+import {getButton, getInputBox, getSectionBlock, getStaticSelectElement, getActionsBlock, getMarkdownBlock} from '../helpers/blockBuilder';
+
+export async function EditModal(
+    appId: string,
+    boardURL: string,
+    messageId: string,
+    boardName: string,
+    // userName: string,
+// ): Promise<Array<Block>> {
+    ): Promise<IUIKitSurfaceViewParam> {
+    const block: Block[] = [];
+
+    /* For Text block */
+    let descBlock = getSectionBlock(UtilityEnum.EDIT_DESC);
+    block.push(descBlock);
+
+    // Cancel Button
+    const dismissalButton = getButton(
+        UtilityEnum.NO,
+        UtilityEnum.NO_EDIT_BLOCK_ID,
+        UtilityEnum.NO_EDIT_ACTION_ID,
+        appId,
+        "No",
+        ButtonStyle.DANGER
+    );
+
+    // Approve Button
+    const approveButton = getButton(
+        UtilityEnum.YES,
+        UtilityEnum.YES_EDIT_BLOCK_ID,
+        UtilityEnum.YES_EDIT_ACTION_ID,
+        appId,
+        `${messageId}, ${boardName}`,
+        ButtonStyle.PRIMARY,
+        boardURL
+    );
+
+    // let inputBlock:SectionBlock;
+    // const yesActionBlock = getActionsBlock(UtilityEnum.YES_EDIT_BLOCK_ID, 
+    //     [
+    //         // dismissalButton,
+    //         approveButton
+    //     ])
+        
+    //     inputBlock = getSectionBlock(UtilityEnum.ARE_YOU_SURE, yesActionBlock);
+    // block.push(inputBlock);
+    // return block
+
+    // block.push(yesActionBlock);
+
+
+    const value = {
+        id: UtilityEnum.EDIT_MODAL_ID,
+        type: UIKitSurfaceType.MODAL,
+        appId: appId,
+        title: {
+            type: "plain_text" as const,
+            text: UtilityEnum.ARE_YOU_SURE,
+        },
+        close: dismissalButton,
+        submit: approveButton,
+        blocks: block,
+    };
+
+
+    return value;
+}
+
+    // let markdownBlock: SectionBlock;
+    // if (boardName == undefined) {
+    //     markdownBlock = getMarkdownBlock(
+    //         `*Untitled Whiteboard* by \`@${userName}\``
+    //     );
+    // } else {
+    //     markdownBlock = getMarkdownBlock(`*${boardName}* by \`@${userName}\``);
+    // }
+
+    // const actionBlock = getActionsBlock(UtilityEnum.PREVIEW_BLOCK_ID, [
+    //     dismissalButton,
+    //     approveButton
+    // ]);
+    // block.push(markdownBlock);
+    // block.push(actionBlock);
+    // return block;

--- a/whiteboard/modals/EditModal.ts
+++ b/whiteboard/modals/EditModal.ts
@@ -33,7 +33,7 @@ export async function EditModal(
 
     // Approve Button
     const approveButton = getButton(
-        UtilityEnum.YES,
+        UtilityEnum.EDIT,
         UtilityEnum.YES_EDIT_BLOCK_ID,
         UtilityEnum.YES_EDIT_ACTION_ID,
         appId,

--- a/whiteboard/modals/EditModal.ts
+++ b/whiteboard/modals/EditModal.ts
@@ -12,8 +12,6 @@ export async function EditModal(
     boardURL: string,
     messageId: string,
     boardName: string,
-    // userName: string,
-// ): Promise<Array<Block>> {
     ): Promise<IUIKitSurfaceViewParam> {
     const block: Block[] = [];
 
@@ -42,19 +40,6 @@ export async function EditModal(
         boardURL
     );
 
-    // let inputBlock:SectionBlock;
-    // const yesActionBlock = getActionsBlock(UtilityEnum.YES_EDIT_BLOCK_ID, 
-    //     [
-    //         // dismissalButton,
-    //         approveButton
-    //     ])
-        
-    //     inputBlock = getSectionBlock(UtilityEnum.ARE_YOU_SURE, yesActionBlock);
-    // block.push(inputBlock);
-    // return block
-
-    // block.push(yesActionBlock);
-
 
     const value = {
         id: UtilityEnum.EDIT_MODAL_ID,
@@ -72,20 +57,3 @@ export async function EditModal(
 
     return value;
 }
-
-    // let markdownBlock: SectionBlock;
-    // if (boardName == undefined) {
-    //     markdownBlock = getMarkdownBlock(
-    //         `*Untitled Whiteboard* by \`@${userName}\``
-    //     );
-    // } else {
-    //     markdownBlock = getMarkdownBlock(`*${boardName}* by \`@${userName}\``);
-    // }
-
-    // const actionBlock = getActionsBlock(UtilityEnum.PREVIEW_BLOCK_ID, [
-    //     dismissalButton,
-    //     approveButton
-    // ]);
-    // block.push(markdownBlock);
-    // block.push(actionBlock);
-    // return block;

--- a/whiteboard/modals/PermissionModal.ts
+++ b/whiteboard/modals/PermissionModal.ts
@@ -1,0 +1,58 @@
+import {
+    ButtonStyle,
+    UIKitSurfaceType,
+} from "@rocket.chat/apps-engine/definition/uikit";
+import { IUIKitSurfaceViewParam } from "@rocket.chat/apps-engine/definition/accessors";
+import { UtilityEnum } from "../enum/uitlityEnum";
+import { Block, Option, InputBlock } from "@rocket.chat/ui-kit";
+import {
+    getButton,
+    getInputBox,
+    getSectionBlock,
+    getStaticSelectElement,
+} from "../helpers/blockBuilder";
+
+export async function PermissionModal(
+    appId: string,
+    messageId: string
+): Promise<IUIKitSurfaceViewParam> {
+    const block: Block[] = [];
+
+    /* For Text block */
+    let descBlock = getSectionBlock(UtilityEnum.PERMISSION_DESC);
+    block.push(descBlock);
+
+    // Cancel Button
+    let dismissalButton = getButton(
+        UtilityEnum.NO,
+        UtilityEnum.NO_BLOCK_ID,
+        UtilityEnum.NO_ACTION_ID,
+        appId,
+        "",
+        undefined
+    );
+
+    // Delete Button
+    const approveButton = getButton(
+        UtilityEnum.YES,
+        UtilityEnum.YES_BLOCK_ID,
+        UtilityEnum.YES_ACTION_ID,
+        appId,
+        messageId,
+        undefined
+    );
+
+    const value = {
+        id: UtilityEnum.PERMISSION_MODAL_ID,
+        type: UIKitSurfaceType.MODAL,
+        appId: appId,
+        title: {
+            type: "plain_text" as const,
+            text: UtilityEnum.PERMISSION_DENIED,
+        },
+        close: dismissalButton,
+        submit: approveButton,
+        blocks: block,
+    };
+    return value;
+}

--- a/whiteboard/persistence/boardInteraction.ts
+++ b/whiteboard/persistence/boardInteraction.ts
@@ -23,7 +23,7 @@ export const storeBoardRecord = async (
     privateMessageId: string,
     status: string,
     boardOwner?: IUser[]
-): Promise<void> => {
+): Promise<string> => {
     const roomAssociation = new RocketChatAssociationRecord(
         RocketChatAssociationModel.ROOM,
         `${roomId}#BoardName`
@@ -49,7 +49,7 @@ export const storeBoardRecord = async (
         "board"
     );
 
-    await persistence.updateByAssociations(
+    const recordId = await persistence.updateByAssociations(
         [
             boardAssociation,
             messageAssociation,
@@ -73,6 +73,8 @@ export const storeBoardRecord = async (
         },
         true
     );
+
+    return recordId
 };
 
 // query all records within the "scope" - room

--- a/whiteboard/persistence/boardInteraction.ts
+++ b/whiteboard/persistence/boardInteraction.ts
@@ -6,6 +6,7 @@ import {
     RocketChatAssociationModel,
     RocketChatAssociationRecord,
 } from "@rocket.chat/apps-engine/definition/metadata";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
 
 //functions needed to persist board data while modal and other UI interactions
 // Messages can be retrieved by using the messageId, privateMessageId and boardId
@@ -20,7 +21,8 @@ export const storeBoardRecord = async (
     cover: string,
     title: string,
     privateMessageId: string,
-    status: string
+    status: string,
+    boardOwner?: IUser[]
 ): Promise<void> => {
     const roomAssociation = new RocketChatAssociationRecord(
         RocketChatAssociationModel.ROOM,
@@ -67,6 +69,7 @@ export const storeBoardRecord = async (
             title,
             privateMessageId,
             status,
+            boardOwner,
         },
         true
     );


### PR DESCRIPTION
This issue closes #71

## How I will proceed:

- First when user creates a board then the roles should change to owner.
- Second, make a persistance or find a persistance which contains the data that contains which user created which board. Meaning which messageId belongs to which user.
- Then make a function which checks whether the user currently accessing has the rights or not. Check the role whether it is admin or owner.
- If the role does not contain admin or owner then notify(checkboard type) the user to ask for permission. If he says yes then notify the admin and the user to give the permission.
- If they allow then first add the user to owner of that board then notify the user that access has been granted to the `${boardName}`