### PR TITLE
Fix: Ensure Attachments Are Visible in sendMessageWithAttachment Function

### DIFF
--- a/whiteboard/lib/messages.ts
+++ b/whiteboard/lib/messages.ts
@@ -96,7 +96,11 @@ export async function sendMessageWithAttachment(
         .setText(message);
 
     if (attachments !== undefined) {
-        msg.setAttachments(attachments);
+        const modifiedAttachments = attachments.map(attachment => ({
+            ...attachment,
+            collapsed: false,
+        }));
+        msg.setAttachments(modifiedAttachments);
     }
     if (blocks !== undefined) {
         msg.setBlocks(blocks);


### PR DESCRIPTION
## Description
This pull request addresses an issue where attachments were being collapsed in the `sendMessageWithAttachment` function. The `collapsed` property of attachments was being set to `true` by default, causing the attachments to be hidden. This PR modifies the `sendMessageWithAttachment` function to ensure the `collapsed` property is set to `false` for all attachments, ensuring they are always visible.

Closes: #83 
## Before fix:
![before_fix](https://github.com/RocketChat/Apps.Whiteboard/assets/123318221/4e62faf8-a1e1-4a3c-9844-46d38293fab4)
## After fix:
![after_fix](https://github.com/RocketChat/Apps.Whiteboard/assets/123318221/0b14a0da-743a-40f3-a9ec-5e5621645022)
